### PR TITLE
fixing "$where not allowed in this atlas tier"

### DIFF
--- a/src/Database.ts
+++ b/src/Database.ts
@@ -412,14 +412,9 @@ export class Database<T = unknown, PAR = unknown> extends TypedEmitter<QmEvents<
      */
     public async all(options?: AllQueryOptions) {
         this.__readyCheck();
-        const everything = await this.model.find({
-            $where: function () {
-                const expiredCheck = !(this.expireAt && this.expireAt.getTime() - Date.now() <= 0);
-                return expiredCheck;
-            }
-        });
+        const everything = await this.model.find({});
         let arb = everything
-            .filter((v) => options?.filter?.({ ID: v.ID, data: v.data }) ?? true)
+            .filter((v) => (options?.filter?.({ ID: v.ID, data: v.data }) ?? true) || !(this.expireAt && this.expireAt.getTime() - Date.now() <= 0))
             .map((m) => ({
                 ID: m.ID,
                 data: this.__formatData(m)

--- a/src/Database.ts
+++ b/src/Database.ts
@@ -414,7 +414,8 @@ export class Database<T = unknown, PAR = unknown> extends TypedEmitter<QmEvents<
         this.__readyCheck();
         const everything = await this.model.find({});
         let arb = everything
-            .filter((v) => (options?.filter?.({ ID: v.ID, data: v.data }) ?? true) || !(this.expireAt && this.expireAt.getTime() - Date.now() <= 0))
+.filter((v) => !(this.expireAt && this.expireAt.getTime() - Date.now() <= 0))
+.filter((v) => options?.filter?.({ ID: v.ID, data: v.data }) ?? true);
             .map((m) => ({
                 ID: m.ID,
                 data: this.__formatData(m)


### PR DESCRIPTION
if a free tier atlas runs db.all it throws a error of `$where not allowed in this atlas tier`.
this fixes it